### PR TITLE
fix status type (array of size MPI_STATUS_SIZE)

### DIFF
--- a/practicals/02.MPI_pt2pt/fortran/1.simple_send_recv_solution.f90
+++ b/practicals/02.MPI_pt2pt/fortran/1.simple_send_recv_solution.f90
@@ -19,7 +19,8 @@ PROGRAM simple_send_recv
    USE MPI
    IMPLICIT NONE
 
-   INTEGER rank, size, number, stat, ierror
+   INTEGER rank, size, number, ierror
+   INTEGER stat(MPI_STATUS_SIZE)
 
    CALL MPI_Init(ierror)
 


### PR DESCRIPTION
A simple argument type mismatch.
